### PR TITLE
introduced include_train and single_precision options

### DIFF
--- a/numerox/data.py
+++ b/numerox/data.py
@@ -16,7 +16,7 @@ N_FEATURES = 310
 ERA_INT_TO_STR = {}
 ERA_STR_TO_INT = {}
 ERA_STR_TO_FLOAT = {}
-for i in range(200):
+for i in range(998):
     name = 'era' + str(i)
     ERA_INT_TO_STR[i] = name
     ERA_STR_TO_INT[name] = i

--- a/numerox/examples/data.rst
+++ b/numerox/examples/data.rst
@@ -17,6 +17,16 @@ Or::
 
 If the download fails then it will by default retry.
 
+You can force the internal CSV parser to use ``float32`` in order to save memory::
+
+    >>> data = nx.download('numerai_dataset.zip', single_precision=True)
+
+By default the training data will be loaded, parsed and included in the data frame. If you need just the tournament dataset, you can set ``include_train`` to ``False``::
+
+    >>> data = nx.download('numerai_dataset.zip', include_train=False)
+
+It won't bother parsing the train data and so it won't need that much memory.
+
 Load data
 ---------
 
@@ -30,7 +40,10 @@ You can create a data object from the zip archive provided by Numerai::
     x         50, min 0.0000, mean 0.5025, max 1.0000
     y         mean 0.499546, fraction missing 0.3093
 
-But that is slow (~7 seconds) which is painful for dedicated overfitters.
+
+You can use ``include_train`` and ``single_precision`` options here as well.
+
+Loading data from ZIP archive is slow (~7 seconds) which is painful for dedicated overfitters.
 Let's convert the zip archive to an HDF5 archive::
 
     >>> data.save('numerai_dataset.hdf')

--- a/numerox/numerai.py
+++ b/numerox/numerai.py
@@ -18,12 +18,14 @@ NMR_PRIZE_POOL = 2000
 # download dataset
 
 def download(filename, load=True, n_tries=100, sleep_seconds=300,
-             verbose=False):
+             verbose=False, include_train=True, single_precision=False):
     """
     Download current Numerai dataset; overwrites if file exists.
 
     If `load` is True (default) then return data object; otherwise return
-    None.
+    None. It will include train data if `include_train` is True as well.
+
+    Set `single_precision` to True in order to load data in float32 precision.
 
     If download fails then retry download `n_tries` times, pausing
     `sleep_seconds` between each try.
@@ -46,7 +48,7 @@ def download(filename, load=True, n_tries=100, sleep_seconds=300,
             time.sleep(sleep_seconds)
         count += 1
     if load:
-        data = nx.load_zip(filename, verbose=verbose)
+        data = nx.load_zip(filename, verbose=verbose, include_train=include_train, single_precision=single_precision)
     else:
         data = None
     return data


### PR DESCRIPTION
This PR focuses on decreasing memory requirements. It introduces options for loading/parsing tournament data only and for forcing CSV parser to use `float32` type instead of default `float64`.

Tests are still broken as their were (no changes to tests), no additional failures or errors detected.