### PR TITLE
Check for submission upload after deadline and bailout avoiding unnecessary retries

### DIFF
--- a/numerox/numerai.py
+++ b/numerox/numerai.py
@@ -123,8 +123,12 @@ def upload(filename,
             break
 
         except Exception as e:  # noqa
-            print('upload failed - %s' % e)
-            time.sleep(sleep_seconds)
+            if str(e).startswith("Can't update submission after deadline"):
+                # Bailout with error message and do not retry uploads
+                raise Exception(e)
+            else:
+                print('Upload exception - %s' % e)
+                time.sleep(sleep_seconds)
         count += 1
 
     else:


### PR DESCRIPTION
Some compute users might have a mix of staked/on-time models and un-staked models they might want to resubmit during the week. Numerox should not retry staked model uploads on error.  