### PR TITLE
New Target Nomi

### DIFF
--- a/numerox/data.py
+++ b/numerox/data.py
@@ -623,8 +623,8 @@ def load_zip(file_path,
     for i in range(1, N_FEATURES + 1):
         rename_map['feature' + str(i)] = 'x' + str(i)
     for number, name in nx.tournament_iter(active_only=True):
-        if number >= 9:
-            # Starting for round 238 (Nomi), training and tournament files will
+        if number >= 8:
+            # Starting for round 238, training and tournament files will
             # contain the target column `target` instead of `target_kazutsugi`.
             rename_map['target'] = name
         else:

--- a/numerox/data.py
+++ b/numerox/data.py
@@ -623,7 +623,12 @@ def load_zip(file_path,
     for i in range(1, N_FEATURES + 1):
         rename_map['feature' + str(i)] = 'x' + str(i)
     for number, name in nx.tournament_iter(active_only=True):
-        rename_map['target_' + name] = name
+        if number >= 9:
+            # Starting for round 238 (Nomi), training and tournament files will
+            # contain the target column `target` instead of `target_kazutsugi`.
+            rename_map['target'] = name
+        else:
+            rename_map['target_' + name] = name
     df.rename(columns=rename_map, inplace=True)
 
     # convert era, region, and labels to np.float32 or np.float64 depending on the mode

--- a/numerox/data.py
+++ b/numerox/data.py
@@ -623,12 +623,7 @@ def load_zip(file_path,
     for i in range(1, N_FEATURES + 1):
         rename_map['feature' + str(i)] = 'x' + str(i)
     for number, name in nx.tournament_iter(active_only=True):
-        if number >= 8:
-            # Starting for round 238, training and tournament files will
-            # contain the target column `target` instead of `target_kazutsugi`.
-            rename_map['target'] = name
-        else:
-            rename_map['target_' + name] = name
+        rename_map['target'] = name
     df.rename(columns=rename_map, inplace=True)
 
     # convert era, region, and labels to np.float32 or np.float64 depending on the mode

--- a/numerox/prediction.py
+++ b/numerox/prediction.py
@@ -341,10 +341,9 @@ class Prediction(object):
         if self.shape[1] != 1:
             raise ValueError("prediction must contain a single pair")
         tourn = self.tournaments(as_str=True)[0]
-        if nx.tournament_int(tourn) >= 9:
-            # Starting for round 238 (Nomi), predictions should be submitted
-            # with the column header `prediction` instead of
-            # `prediction_kazutsugi`.
+        if nx.tournament_int(tourn) >= 8:
+            # Starting for round 238, predictions should be submitted with the
+            # column header `prediction` instead of `prediction_kazutsugi`.
             df = self.df.iloc[:, 0].to_frame('prediction')
         else:
             df = self.df.iloc[:, 0].to_frame('probability_' + tourn)

--- a/numerox/prediction.py
+++ b/numerox/prediction.py
@@ -341,7 +341,13 @@ class Prediction(object):
         if self.shape[1] != 1:
             raise ValueError("prediction must contain a single pair")
         tourn = self.tournaments(as_str=True)[0]
-        df = self.df.iloc[:, 0].to_frame('probability_' + tourn)
+        if nx.tournament_int(tourn) >= 9:
+            # Starting for round 238 (Nomi), predictions should be submitted
+            # with the column header `prediction` instead of
+            # `prediction_kazutsugi`.
+            df = self.df.iloc[:, 0].to_frame('prediction')
+        else:
+            df = self.df.iloc[:, 0].to_frame('probability_' + tourn)
         df.index.rename('id', inplace=True)
         float_format = "%.{}f".format(decimals)
         df.to_csv(path_or_buf, float_format=float_format)

--- a/numerox/prediction.py
+++ b/numerox/prediction.py
@@ -340,13 +340,7 @@ class Prediction(object):
         "Save a csv file of predictions; prediction must contain only one pair"
         if self.shape[1] != 1:
             raise ValueError("prediction must contain a single pair")
-        tourn = self.tournaments(as_str=True)[0]
-        if nx.tournament_int(tourn) >= 8:
-            # Starting for round 238, predictions should be submitted with the
-            # column header `prediction` instead of `prediction_kazutsugi`.
-            df = self.df.iloc[:, 0].to_frame('prediction')
-        else:
-            df = self.df.iloc[:, 0].to_frame('probability_' + tourn)
+        df = self.df.iloc[:, 0].to_frame('prediction')
         df.index.rename('id', inplace=True)
         float_format = "%.{}f".format(decimals)
         df.to_csv(path_or_buf, float_format=float_format)

--- a/numerox/tournament.py
+++ b/numerox/tournament.py
@@ -31,10 +31,6 @@ TOURNAMENTS = [{
 }, {
     'name': 'kazutsugi',
     'number': 8,
-    'active': False
-}, {
-    'name': 'nomi',
-    'number': 9,
     'active': True
 }]
 

--- a/numerox/tournament.py
+++ b/numerox/tournament.py
@@ -31,6 +31,10 @@ TOURNAMENTS = [{
 }, {
     'name': 'kazutsugi',
     'number': 8,
+    'active': False
+}, {
+    'name': 'nomi',
+    'number': 9,
     'active': True
 }]
 


### PR DESCRIPTION
# Description
Starting for round 238, the official target will be Nomi. This will bring the following changes:

- training and tournament files will contain the target column `target` instead of `target_kazutsugi`
- predictions should be submitted with the column header `prediction` instead of `prediction_kazutsugi`

# Changes
This pull request defines a new tournament `nomi` and changes the mentioned column headers.

I'm somehow confused as the column name for the predictions was `'probability_' + tourn` but I expected it to be `'prediction_' + tourn`. Probably this just doesn't get checked.